### PR TITLE
Updates sandbox with example component using AisCurrentRefinements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1325,9 +1325,9 @@
             }
         },
         "@types/googlemaps": {
-            "version": "3.39.7",
-            "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.39.7.tgz",
-            "integrity": "sha512-U8ZjnjfGiZXzun8jIDOZ/5Gt5Ky07B9pBhFbgzten1S364bnuueFsCt5e5V7Wn55o26NkLWgc6becL+j401bRw=="
+            "version": "3.39.11",
+            "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.39.11.tgz",
+            "integrity": "sha512-GRgIICsibETwIC3IiK1U7dluJ/+vpdhIrySiyhTgZhe6Jqwz24GZePWqSvWepZer0NafmILEGe2U4CNAuwCpbw=="
         },
         "@types/json-schema": {
             "version": "7.0.5",
@@ -2551,9 +2551,9 @@
             }
         },
         "algoliasearch-helper": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.1.2.tgz",
-            "integrity": "sha512-HfCVvmKH6+5OU9/SaHLdhvr39DBObA02z62RsfPhFDftzgQM6pJB2JoPyGpIteHW4RAYh8bPLiB8l4hajuy6fA==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.2.2.tgz",
+            "integrity": "sha512-/3XvE33R+gQKaiPdy3nmHYqhF8hqIu8xnlOicVxb1fD6uMFmxW8rGLzzrRfsPfxgAfm+c1NslLb3TzQVIB8aVA==",
             "requires": {
                 "events": "^1.1.1"
             },
@@ -9570,9 +9570,9 @@
             "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
         },
         "preact": {
-            "version": "10.4.4",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.4.tgz",
-            "integrity": "sha512-EaTJrerceyAPatQ+vfnadoopsMBZAOY7ak9ogVdUi5xbpR8SoHgtLryXnW+4mQOwt21icqoVR1brkU2dq7pEBA=="
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.6.tgz",
+            "integrity": "sha512-80WJfXH53yyINig5Wza/8MD9n4lMg9G6aN00ws0ptsAaY/Fu/M7xW4zICf7OLfocVltxS30wvNQ8oIbUyZS1tw=="
         },
         "prelude-ls": {
             "version": "1.1.2",
@@ -11894,12 +11894,12 @@
             "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
         },
         "vue-instantsearch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/vue-instantsearch/-/vue-instantsearch-3.0.3.tgz",
-            "integrity": "sha512-ry2VtYi0iKxjlioLN7bEp5hQDYH/4vX9GBlw64LNQIqsOmK6s/tEl/ZBSq8tdOS46vkpvhjaTRk9ZoOFCjKJXQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vue-instantsearch/-/vue-instantsearch-3.1.0.tgz",
+            "integrity": "sha512-N5dMayDjsWBP7hNXY0OSapYHFtcoG42J0kiFfRYBWyRVrOB7fekOybKBp8iGjZicAeJbiqTbUQa/wRIMtJQBWQ==",
             "requires": {
                 "algoliasearch-helper": "^3.1.0",
-                "instantsearch.js": "^4.5.0"
+                "instantsearch.js": "^4.7.0"
             }
         },
         "vue-loader": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "koa-static": "^5.0.0",
         "serve-static": "^1.13.2",
         "vue": "^2.6.11",
-        "vue-instantsearch": "^3.0.3",
+        "vue-instantsearch": "^3.1.0",
         "vue-router": "^3.3.4"
     },
     "devDependencies": {

--- a/src/components/SelectedFilters.vue
+++ b/src/components/SelectedFilters.vue
@@ -1,0 +1,16 @@
+<template>
+    <div>
+        <AisCurrentRefinements />
+    </div>
+</template>
+
+<script>
+import { AisCurrentRefinements } from 'vue-instantsearch';
+
+export default {
+    name: 'SelectedFilters',
+    components: {
+        AisCurrentRefinements,
+    },
+};
+</script>

--- a/src/components/SelectedFilters.vue
+++ b/src/components/SelectedFilters.vue
@@ -1,15 +1,17 @@
 <template>
     <div>
         <AisCurrentRefinements />
+        <AisClearRefinements />
     </div>
 </template>
 
 <script>
-import { AisCurrentRefinements } from 'vue-instantsearch';
+import { AisClearRefinements, AisCurrentRefinements } from 'vue-instantsearch';
 
 export default {
     name: 'SelectedFilters',
     components: {
+        AisClearRefinements,
         AisCurrentRefinements,
     },
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,4 +2,5 @@ export { default as Configure } from './Configure.vue';
 export { default as Hits } from './Hits.vue';
 export { default as Pagination } from './Pagination.vue';
 export { default as RefinementList } from './RefinementList.vue';
+export { default as SelectedFilters } from './SelectedFilters.vue';
 export { default as SortBy } from './SortBy.vue';

--- a/src/modules/createInstantSearchRouting.js
+++ b/src/modules/createInstantSearchRouting.js
@@ -22,7 +22,7 @@ export default ({ context, indexName }) => ({
             });
 
             if (typeof history === 'object') {
-                history.pushState(routeState, null, query);
+                history.pushState(routeState, null, query || location.pathname);
             }
         },
         createURL(routeState) {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -8,6 +8,7 @@
             <AisSearchBox />
             <AisStats />
             <SortBy />
+            <SelectedFilters />
             <RefinementList />
             <Hits :sweetwater-inventory="sweetwaterInventory" />
             <Pagination />
@@ -23,6 +24,7 @@ import {
     Hits,
     Pagination,
     RefinementList,
+    SelectedFilters,
     SortBy,
 } from '@/components';
 
@@ -36,6 +38,7 @@ export default {
         Hits,
         Pagination,
         RefinementList,
+        SelectedFilters,
         SortBy,
     },
     data() {


### PR DESCRIPTION
This PR updates the current sandbox with a `SelectedFilters` component that is added to the Search view to show the current refinements functionality in action (it is broken right now, but this sandbox shows this issue and will hopefully be resolved by Algolia).

I also updated `vue-instantsearch` to the latest version: 3.1.0.